### PR TITLE
Fixed style reset

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
     {
       "matches": ["<all_urls>"],
       "js": ["contentScript.js"],
-      "run_at": "document_start"
+      "run_at": "document_end"
     }
   ]
 }


### PR DESCRIPTION
Page style resets on refresh / new pages do not blockify even though the extension is enabled. This should fix it now

